### PR TITLE
Added "Devolo Wifi Stick ac"

### DIFF
--- a/common/rtusb_dev_id.c
+++ b/common/rtusb_dev_id.c
@@ -41,6 +41,7 @@ USB_DEVICE_ID rtusb_dev_id[] = {
 	{USB_DEVICE(0x13B1,0x003E)}, /* Cisco Linksys AE6000 */
    	{USB_DEVICE(0x7392,0xA711)}, /* Edimax 7711ULC/7711MAC */
    	{USB_DEVICE(0x7392,0xB711)}, /* Elecom WDC-433SU2M */
+	{USB_DEVICE(0x7392,0xC711)}, /* Devolo Wifi Stick ac */
 	{USB_DEVICE(0x148F,0x761A)}, /* TP-LINK Archer T2UH */
 	{USB_DEVICE(0x148F,0x760A)}, /* TP-LINK */
 	{USB_DEVICE(0x0B05,0x17D1)}, /* ASUS USB-AC51 */


### PR DESCRIPTION
See also: http://unix.stackexchange.com/questions/315555/edimax-7392c711-wifi-adapter-driver-needed-for-linux-mint-18
