### PR TITLE
Fixed an issue where module would panic and crash after a scan.

### DIFF
--- a/os/linux/rt_linux.c
+++ b/os/linux/rt_linux.c
@@ -3269,7 +3269,7 @@ VOID CFG80211OS_ScanEnd(
 
 
 	CFG80211DBG(RT_DEBUG_ERROR, ("80211> cfg80211_scan_done\n"));
-	cfg80211_scan_done(pCfg80211_CB->pCfg80211_ScanReq, FlgIsAborted);
+	cfg80211_scan_done(pCfg80211_CB->pCfg80211_ScanReq, &(pCfg80211_CB->pCfg80211_ScanReq->info)); //FlgIsAborted);
 #endif /* CONFIG_STA_SUPPORT */
 #endif /* LINUX_VERSION_CODE */
 }


### PR DESCRIPTION
The old code had a boolean passed where it wanted a cfg80211_scan_info,
which then cause a dereference of a nullptr.
This has been replaced with a pass of the info part of the scan request.