### PR TITLE
Remove troublesome ampersand

### DIFF
--- a/os/linux/sta_ioctl.c
+++ b/os/linux/sta_ioctl.c
@@ -693,7 +693,7 @@ int rt_ioctl_iwaplist(struct net_device *dev,
 		set_quality(pAd, &qual[i], pList); /*&pAd->ScanTab.BssEntry[i]); */
 	}
 	data->length = i;
-	memcpy(extra, &addr, i*sizeof(addr[0]));
+	memcpy(extra, addr, i*sizeof(addr[0]));
 	data->flags = 1;		/* signal quality present (sort of) */
 	memcpy(extra + i*sizeof(addr[0]), &qual, i*sizeof(qual[i]));
 


### PR DESCRIPTION
Deleted a single buggy ampersand which was breaking compile on the new kernel (4.13)